### PR TITLE
Add MIT License Declaration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 The Algorithms
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Contribution Guidelines
  - If you add an algorithm then you have to add a test (JUnit) along with it. In the absence of a test, the PR will not be approved.
  - Follow the correct coding guidelines with proper description of the methods. Refer [Kotlin Coding Standards](https://kotlinlang.org/docs/reference/coding-conventions.html).
- - Your work will be distributed under [MIT License](License) once your pull request is merged.
+ - Your work will be distributed under [MIT License](LICENSE) once your pull request is merged.
  - Please do not add a signature inside the code. The commit history is sufficient to determine who has added the code to the repo.
  - Make sure the algorithm which is getting added comes under a certain domain of Algorithms. Please don't create a package with a name such as Misc, Others, etc. 
  - While making a PR, make sure you are committing the Kotlin files only and not any project specific files. If you feel that your IDE is generating some extra files, then either don't add them to git, or add the extensions to ```.gitignore```.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Contribution Guidelines
  - If you add an algorithm then you have to add a test (JUnit) along with it. In the absence of a test, the PR will not be approved.
  - Follow the correct coding guidelines with proper description of the methods. Refer [Kotlin Coding Standards](https://kotlinlang.org/docs/reference/coding-conventions.html).
+ - Your work will be distributed under [MIT License](License) once your pull request is merged.
  - Please do not add a signature inside the code. The commit history is sufficient to determine who has added the code to the repo.
  - Make sure the algorithm which is getting added comes under a certain domain of Algorithms. Please don't create a package with a name such as Misc, Others, etc. 
  - While making a PR, make sure you are committing the Kotlin files only and not any project specific files. If you feel that your IDE is generating some extra files, then either don't add them to git, or add the extensions to ```.gitignore```.


### PR DESCRIPTION
The PR adds MIT License following the sister repositories and adds a link in contribution guideline to the license.